### PR TITLE
Add toast feedback when saving shopping list

### DIFF
--- a/app.R
+++ b/app.R
@@ -873,7 +873,7 @@ server <- function(input, output, session) {
     
     path <- paste0("./data/indkobssedler/indkobsseddel_", gsub("-", "", Sys.Date()), ".rda")
     save(df, file = path)
-    shinyjs::runjs("showCopyToast(\"Indkøbsseddel gemt ✔\", \"blue\")")
+    runjs("showCopyToast(\"Indkøbsseddel gemt ✔\", \"blue\")")
     
   })
   

--- a/app.R
+++ b/app.R
@@ -61,7 +61,7 @@ ui <- f7Page(
         DT::DTOutput("indkobsseddel"),
         f7Block(
           f7Button("gem_indkobsseddel", "Gem indkøbssedlen til database", 
-                   fill = TRUE, color = "blue"),
+                   fill = TRUE, color = "blue", class = "ga-save-btn"),
         ),
         h5(strong("Forslag til manglende varer:")),
         tableOutput("tidl_kob"),

--- a/app.R
+++ b/app.R
@@ -873,7 +873,7 @@ server <- function(input, output, session) {
     
     path <- paste0("./data/indkobssedler/indkobsseddel_", gsub("-", "", Sys.Date()), ".rda")
     save(df, file = path)
-    session$sendCustomMessage("show_toast", list(text = "Indkøbsseddel gemt ✔"))
+    shinyjs::runjs("showCopyToast(\"Indkøbsseddel gemt ✔\")")
     
   })
   

--- a/app.R
+++ b/app.R
@@ -873,6 +873,7 @@ server <- function(input, output, session) {
     
     path <- paste0("./data/indkobssedler/indkobsseddel_", gsub("-", "", Sys.Date()), ".rda")
     save(df, file = path)
+    session$sendCustomMessage("show_toast", list(text = "Indkøbsseddel gemt ✔"))
     
   })
   

--- a/app.R
+++ b/app.R
@@ -61,7 +61,7 @@ ui <- f7Page(
         DT::DTOutput("indkobsseddel"),
         f7Block(
           f7Button("gem_indkobsseddel", "Gem indkøbssedlen til database", 
-                   fill = TRUE, color = "blue", class = "ga-save-btn"),
+                   fill = TRUE, color = "blue"),
         ),
         h5(strong("Forslag til manglende varer:")),
         tableOutput("tidl_kob"),

--- a/app.R
+++ b/app.R
@@ -873,7 +873,7 @@ server <- function(input, output, session) {
     
     path <- paste0("./data/indkobssedler/indkobsseddel_", gsub("-", "", Sys.Date()), ".rda")
     save(df, file = path)
-    shinyjs::runjs("showCopyToast(\"Indkøbsseddel gemt ✔\")")
+    shinyjs::runjs("showCopyToast(\"Indkøbsseddel gemt ✔\", \"blue\")")
     
   })
   

--- a/www/DT-copy-feedback.js
+++ b/www/DT-copy-feedback.js
@@ -1,6 +1,6 @@
 // www/copy-feedback.js
 
-window.showCopyToast = function (message) {
+window.showCopyToast = function (message, tone) {
   var toast = document.getElementById("copy-toast");
   if (!toast) {
     toast = document.createElement("div");
@@ -10,6 +10,10 @@ window.showCopyToast = function (message) {
   }
 
   toast.innerText = message || "Indkøbsliste kopieret ✔";
+
+  var toastTone = tone || "green";
+  toast.classList.remove("toast-green", "toast-blue");
+  toast.classList.add(toastTone === "blue" ? "toast-blue" : "toast-green");
   toast.classList.add("show");
 
   // Sørg for at flere klik bare forlænger samme toast
@@ -40,12 +44,13 @@ window.copyWithFeedback = function (e, dt, node, config) {
   }, 150);
 
   // 3) Lille toast-notifikation
-  showCopyToast("Indkøbsliste kopieret ✔");
+  showCopyToast("Indkøbsliste kopieret ✔", "green");
 };
 
 if (window.Shiny && window.Shiny.addCustomMessageHandler) {
   window.Shiny.addCustomMessageHandler("show_toast", function (msg) {
     var text = msg && msg.text ? msg.text : "Udført ✔";
-    showCopyToast(text);
+    var tone = msg && msg.tone ? msg.tone : "green";
+    showCopyToast(text, tone);
   });
 }

--- a/www/DT-copy-feedback.js
+++ b/www/DT-copy-feedback.js
@@ -1,6 +1,6 @@
 // www/copy-feedback.js
 
-function showCopyToast(message) {
+window.showCopyToast = function (message) {
   var toast = document.getElementById("copy-toast");
   if (!toast) {
     toast = document.createElement("div");

--- a/www/DT-copy-feedback.js
+++ b/www/DT-copy-feedback.js
@@ -1,5 +1,24 @@
 // www/copy-feedback.js
 
+function showCopyToast(message) {
+  var toast = document.getElementById("copy-toast");
+  if (!toast) {
+    toast = document.createElement("div");
+    toast.id = "copy-toast";
+    toast.className = "copy-toast";
+    document.body.appendChild(toast);
+  }
+
+  toast.innerText = message || "Indkøbsliste kopieret ✔";
+  toast.classList.add("show");
+
+  // Sørg for at flere klik bare forlænger samme toast
+  clearTimeout(window.copyToastTimeout);
+  window.copyToastTimeout = setTimeout(function () {
+    toast.classList.remove("show");
+  }, 2000);
+}
+
 // Gør funktionen global, så DT::JS("copyWithFeedback") kan finde den
 window.copyWithFeedback = function (e, dt, node, config) {
   // 1) Kør standard copy-aktion (brug copyHtml5-varianten)
@@ -21,20 +40,12 @@ window.copyWithFeedback = function (e, dt, node, config) {
   }, 150);
 
   // 3) Lille toast-notifikation
-  var toast = document.getElementById("copy-toast");
-  if (!toast) {
-    toast = document.createElement("div");
-    toast.id = "copy-toast";
-    toast.className = "copy-toast";
-    toast.innerText = "Indkøbsliste kopieret ✔";
-    document.body.appendChild(toast);
-  }
-
-  toast.classList.add("show");
-
-  // Sørg for at flere klik bare forlænger samme toast
-  clearTimeout(window.copyToastTimeout);
-  window.copyToastTimeout = setTimeout(function () {
-    toast.classList.remove("show");
-  }, 2000);
+  showCopyToast("Indkøbsliste kopieret ✔");
 };
+
+if (window.Shiny && window.Shiny.addCustomMessageHandler) {
+  window.Shiny.addCustomMessageHandler("show_toast", function (msg) {
+    var text = msg && msg.text ? msg.text : "Udført ✔";
+    showCopyToast(text);
+  });
+}

--- a/www/styles.css
+++ b/www/styles.css
@@ -410,7 +410,7 @@ button.dt-button.copy-btn-pushed {
 
 
 /* Gem-knap med præcis samme blå hex som blå toast */
-.ga-save-btn {
+button#gem_indkobsseddel {
   background: #0ea5e9 !important;
   border: 1px solid #0ea5e9 !important;
   color: #ffffff !important;

--- a/www/styles.css
+++ b/www/styles.css
@@ -395,11 +395,11 @@ button.dt-button.copy-btn-pushed {
 }
 
 #copy-toast.toast-green {
-  background: #16a34a;
+  background: #22c55e;
 }
 
 #copy-toast.toast-blue {
-  background: #2563eb;
+  background: #0ea5e9;
 }
 
 #copy-toast.show {
@@ -407,6 +407,14 @@ button.dt-button.copy-btn-pushed {
   transform: translateX(-50%) translateY(0);
 }
 
+
+
+/* Gem-knap med præcis samme blå hex som blå toast */
+.ga-save-btn {
+  background: #0ea5e9 !important;
+  border: 1px solid #0ea5e9 !important;
+  color: #ffffff !important;
+}
 
 /* Tab: opskrifter
    Sørg for at overskriften ikke gemmer sig under navbaren,

--- a/www/styles.css
+++ b/www/styles.css
@@ -383,7 +383,6 @@ button.dt-button.copy-btn-pushed {
   bottom: 18px;
   left: 50%;
   transform: translateX(-50%) translateY(8px);
-  background: #16a34a;
   color: #ffffff;
   padding: 6px 14px;
   border-radius: 999px;
@@ -393,6 +392,14 @@ button.dt-button.copy-btn-pushed {
   transition: opacity 0.2s ease, transform 0.2s ease;
   z-index: 9999;
   white-space: nowrap;
+}
+
+#copy-toast.toast-green {
+  background: #16a34a;
+}
+
+#copy-toast.toast-blue {
+  background: #2563eb;
 }
 
 #copy-toast.show {


### PR DESCRIPTION
### Motivation
- Provide visible feedback to the user when the "Gem indkøbssedlen til database" button is pressed, matching the existing feedback used for the "Kopiér indkøbslisten" action.

### Description
- Added a reusable `showCopyToast` helper in `www/DT-copy-feedback.js` for rendering toast messages from multiple triggers.
- Routed the existing DataTables copy action to use the new helper (`Indkøbsliste kopieret ✔`) instead of duplicating toast logic.
- Added a Shiny custom message handler (`show_toast`) in `www/DT-copy-feedback.js` so server-side code can trigger the same toast UI.
- Updated the `observeEvent(input$gem_indkobsseddel, ...)` in `app.R` to send `session$sendCustomMessage("show_toast", list(text = "Indkøbsseddel gemt ✔"))` after saving the file.

### Testing
- Ran `node --check www/DT-copy-feedback.js` which completed successfully.
- Attempted to parse/run R checks with `Rscript`/`R`, but those tools are not installed in the environment so the checks could not be executed.
- Attempted a Playwright-based screenshot of the running Shiny app, but the app server was not running so the check failed with a network error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990362bc59c8328a3a658c3a44e0a89)