### PR TITLE
Add mobile PWA meta tags and iOS safe-area CSS adjustments

### DIFF
--- a/app.R
+++ b/app.R
@@ -17,6 +17,13 @@ ui <- f7Page(
   
   # opsætning ----
   tags$head(
+    tags$meta(
+      name = "viewport",
+      content = "width=device-width, initial-scale=1, viewport-fit=cover"
+    ),
+    tags$meta(name = "apple-mobile-web-app-capable", content = "yes"),
+    tags$meta(name = "apple-mobile-web-app-status-bar-style", content = "black-translucent"),
+    tags$meta(name = "mobile-web-app-capable", content = "yes"),
     includeCSS("www/styles.css"),
     fa_html_dependency(),
     htmltools::singleton(tags$script(src = "selectize-mobile.js")),

--- a/www/styles.css
+++ b/www/styles.css
@@ -422,3 +422,34 @@ button#gem_indkobsseddel {
 .opskrift-anchor {
   scroll-margin-top: 80px; /* justér evt. til 70/90 afhængigt af navbar-højde */
 }
+
+/* --- iOS PWA (standalone) viewport + safe-area finetuning --- */
+:root {
+  --ga-safe-right: env(safe-area-inset-right, 0px);
+  --ga-safe-bottom: env(safe-area-inset-bottom, 0px);
+  --ga-safe-left: env(safe-area-inset-left, 0px);
+}
+
+/* Brug dynamisk viewport-højde i app-sider */
+.view,
+.view-main,
+.page {
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
+}
+
+/* Kun i installeret webapp-tilstand (hjemmeskærm) */
+@media (display-mode: standalone) {
+  body {
+    padding-left: var(--ga-safe-left);
+    padding-right: var(--ga-safe-right);
+    padding-bottom: var(--ga-safe-bottom);
+  }
+
+  .toolbar,
+  .tabbar,
+  .tabbar-icons {
+    padding-bottom: var(--ga-safe-bottom);
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve mobile and iOS PWA behavior by providing appropriate viewport and web-app meta tags and by handling iOS safe-area insets and dynamic viewport heights to avoid UI elements being obscured.
- Prevent content or headings from being hidden behind the navbar or system UI when the app is used as an installed web app (standalone) on iOS devices.

### Description
- Added meta tags in `tags$head` of `app.R`: `viewport`, `apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`, and `mobile-web-app-capable` to enable proper mobile/PWA behavior.
- Extended `www/styles.css` with `:root` safe-area CSS variables using `env(safe-area-inset-*)` and added dynamic viewport height fallbacks (`100vh`, `100svh`, `100dvh`) for `.view`, `.view-main`, and `.page`.
- Added an `@media (display-mode: standalone)` block that applies padding using the safe-area variables to `body` and adjusts bottom padding for `.toolbar`, `.tabbar`, and `.tabbar-icons` to avoid overlap with the home indicator.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac3da0945883288a83af2a01cd1f5f)