### PR TITLE
Add PWA viewport fix and iOS safe-area support

### DIFF
--- a/app.R
+++ b/app.R
@@ -17,12 +17,20 @@ ui <- f7Page(
   
   # opsætning ----
   tags$head(
+    tags$meta(
+      name = "viewport",
+      content = "width=device-width, initial-scale=1, viewport-fit=cover"
+    ),
+    tags$meta(name = "apple-mobile-web-app-capable", content = "yes"),
+    tags$meta(name = "apple-mobile-web-app-status-bar-style", content = "black-translucent"),
+    tags$meta(name = "mobile-web-app-capable", content = "yes"),
     includeCSS("www/styles.css"),
     fa_html_dependency(),
     htmltools::singleton(tags$script(src = "selectize-mobile.js")),
     htmltools::singleton(tags$script(src = "button-press.js")),
     htmltools::singleton(tags$script(src = "copy-helper.js")),
-    htmltools::singleton(tags$script(src = "DT-copy-feedback.js"))
+    htmltools::singleton(tags$script(src = "DT-copy-feedback.js")),
+    htmltools::singleton(tags$script(src = "pwa-viewport-fix.js"))
   ),
   
   useShinyjs(),

--- a/www/pwa-viewport-fix.js
+++ b/www/pwa-viewport-fix.js
@@ -1,0 +1,27 @@
+(function () {
+  function inStandaloneMode() {
+    return window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
+  }
+
+  function setStandaloneClass() {
+    document.documentElement.classList.toggle('ga-standalone', inStandaloneMode());
+  }
+
+  function setViewportUnit() {
+    var vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--ga-vh', vh + 'px');
+  }
+
+  setStandaloneClass();
+  setViewportUnit();
+
+  window.addEventListener('resize', function () {
+    setStandaloneClass();
+    setViewportUnit();
+  });
+
+  window.addEventListener('orientationchange', function () {
+    setStandaloneClass();
+    setViewportUnit();
+  });
+})();

--- a/www/styles.css
+++ b/www/styles.css
@@ -422,3 +422,56 @@ button#gem_indkobsseddel {
 .opskrift-anchor {
   scroll-margin-top: 80px; /* justér evt. til 70/90 afhængigt af navbar-højde */
 }
+
+/* --- iOS PWA (standalone) viewport + safe-area finetuning --- */
+:root {
+  --ga-safe-top: env(safe-area-inset-top, 0px);
+  --ga-safe-right: env(safe-area-inset-right, 0px);
+  --ga-safe-bottom: env(safe-area-inset-bottom, 0px);
+  --ga-safe-left: env(safe-area-inset-left, 0px);
+  --ga-vh: 1vh;
+}
+
+/* Brug dynamisk viewport-højde i app-sider */
+.view,
+.view-main,
+.page {
+  min-height: calc(var(--ga-vh) * 100);
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
+}
+
+/* Kun i installeret webapp-tilstand (hjemmeskærm).
+   Både media query og klasse bruges for bred iOS-understøttelse. */
+@media (display-mode: standalone) {
+  body,
+  html.ga-standalone body {
+    padding-top: var(--ga-safe-top);
+    padding-left: var(--ga-safe-left);
+    padding-right: var(--ga-safe-right);
+    padding-bottom: var(--ga-safe-bottom);
+  }
+
+  .toolbar,
+  .tabbar,
+  .tabbar-icons,
+  html.ga-standalone .toolbar,
+  html.ga-standalone .tabbar,
+  html.ga-standalone .tabbar-icons {
+    padding-bottom: var(--ga-safe-bottom);
+  }
+}
+
+html.ga-standalone body {
+  padding-top: var(--ga-safe-top);
+  padding-left: var(--ga-safe-left);
+  padding-right: var(--ga-safe-right);
+  padding-bottom: var(--ga-safe-bottom);
+}
+
+html.ga-standalone .toolbar,
+html.ga-standalone .tabbar,
+html.ga-standalone .tabbar-icons {
+  padding-bottom: var(--ga-safe-bottom);
+}


### PR DESCRIPTION
### Motivation
- Prevent layout issues when the app is installed to the home screen (iOS/standalone PWAs) where 100vh and safe-area insets can cause content to be hidden under the notch or home indicator.
- Ensure the UI uses a dynamic viewport height unit and a standalone detection hook so padding and toolbars can be adjusted reliably on resize and orientation changes.
- Improve PWA compatibility by advertising mobile web app capabilities in the HTML head.

### Description
- Added mobile/PWA meta tags in `app.R` (`viewport`, `apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`, `mobile-web-app-capable`).
- Included a new script `www/pwa-viewport-fix.js` from `app.R` which toggles an `ga-standalone` class and sets a dynamic `--ga-vh` CSS variable based on `window.innerHeight`, and updates on `resize` and `orientationchange` events.
- Extended `www/styles.css` with `--ga-safe-*` environment variables, rules that use `--ga-vh` for view height, and styles that apply additional padding for `html.ga-standalone` and `@media (display-mode: standalone)` so toolbars and tabbars are not obscured by safe areas.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac3da0945883288a83af2a01cd1f5f)