### PR TITLE
Improve iPhone standalone (PWA) viewport sizing

### DIFF
--- a/www/pwa-viewport-fix.js
+++ b/www/pwa-viewport-fix.js
@@ -1,4 +1,6 @@
 (function () {
+  var viewportMeta = document.querySelector('meta[name="viewport"]');
+
   function inStandaloneMode() {
     return window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
   }
@@ -7,21 +9,53 @@
     document.documentElement.classList.toggle('ga-standalone', inStandaloneMode());
   }
 
-  function setViewportUnit() {
+  function setViewportUnits() {
     var vh = window.innerHeight * 0.01;
+    var vw = window.innerWidth * 0.01;
+
+    if (window.visualViewport) {
+      vh = window.visualViewport.height * 0.01;
+      vw = window.visualViewport.width * 0.01;
+    }
+
     document.documentElement.style.setProperty('--ga-vh', vh + 'px');
+    document.documentElement.style.setProperty('--ga-vw', vw + 'px');
+  }
+
+  function syncViewportMeta() {
+    if (!viewportMeta) return;
+
+    if (inStandaloneMode()) {
+      viewportMeta.setAttribute(
+        'content',
+        'width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover'
+      );
+      return;
+    }
+
+    viewportMeta.setAttribute(
+      'content',
+      'width=device-width, initial-scale=1, viewport-fit=cover'
+    );
   }
 
   setStandaloneClass();
-  setViewportUnit();
+  setViewportUnits();
+  syncViewportMeta();
 
   window.addEventListener('resize', function () {
     setStandaloneClass();
-    setViewportUnit();
+    setViewportUnits();
+    syncViewportMeta();
   });
 
   window.addEventListener('orientationchange', function () {
     setStandaloneClass();
-    setViewportUnit();
+    setViewportUnits();
+    syncViewportMeta();
   });
+
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', setViewportUnits);
+  }
 })();

--- a/www/styles.css
+++ b/www/styles.css
@@ -430,9 +430,23 @@ button#gem_indkobsseddel {
   --ga-safe-bottom: env(safe-area-inset-bottom, 0px);
   --ga-safe-left: env(safe-area-inset-left, 0px);
   --ga-vh: 1vh;
+  --ga-vw: 1vw;
 }
 
-/* Brug dynamisk viewport-højde i app-sider */
+/* Brug dynamisk viewport-størrelse i app-sider */
+html,
+body,
+#app,
+.views,
+.view,
+.view-main,
+.page,
+.page-content {
+  width: 100%;
+  max-width: 100%;
+  min-width: calc(var(--ga-vw) * 100);
+}
+
 .view,
 .view-main,
 .page {
@@ -474,4 +488,15 @@ html.ga-standalone .toolbar,
 html.ga-standalone .tabbar,
 html.ga-standalone .tabbar-icons {
   padding-bottom: var(--ga-safe-bottom);
+}
+
+html.ga-standalone,
+html.ga-standalone body {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+html.ga-standalone .page-content {
+  padding-bottom: calc(var(--ga-safe-bottom) + 16px);
 }


### PR DESCRIPTION
### Motivation
- The app when added to the iPhone homescreen (standalone/PWA mode) did not consistently match the physical viewport size and could produce layout/overflow issues compared to Safari.
- Need to account for both dynamic viewport height and width on modern iOS and other browsers to avoid clipped content and incorrect container widths.
- Also ensure `meta[name="viewport"]` and safe-area spacing are consistent when running as a standalone webapp.

### Description
- Updated `www/pwa-viewport-fix.js` to compute and expose both `--ga-vh` and `--ga-vw`, prefer `window.visualViewport` when available, and listen to `visualViewport.resize` for more accurate updates.
- Added `syncViewportMeta()` in the JS to keep the `meta[name="viewport"]` content in sync with standalone mode and set `maximum-scale=1` while installed to stabilize layout on iOS.
- Hardened `www/styles.css` by adding `--ga-vw`, enforcing full-width constraints for Framework7/Shiny containers (`html, body, .view, .page-content` etc.), preventing horizontal overflow in `html.ga-standalone`, and adding a small bottom padding buffer for safe-area insets.

### Testing
- Ran `node --check www/pwa-viewport-fix.js` which succeeded and reported no syntax errors.
- Attempted R source parse via `Rscript -e "invisible(parse(file='app.R')); invisible(parse(file='data.R')); invisible(parse(file='funktioner.R'))"` but it failed because `Rscript` is not available in the environment. 
- Attempted a Playwright screenshot against `http://127.0.0.1:3838` but the app server was not running so the request failed with `ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0cf996d8832885eded1060a3fc42)