### PR TITLE
Improve PWA viewport handling and add runtime diagnostics panel

### DIFF
--- a/www/pwa-viewport-fix.js
+++ b/www/pwa-viewport-fix.js
@@ -1,4 +1,7 @@
 (function () {
+  var DIAG_QUERY_KEY = 'gaDebugViewport';
+  var DIAG_STORAGE_KEY = 'ga-debug-viewport';
+
   function inStandaloneMode() {
     return window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
   }
@@ -7,21 +10,122 @@
     document.documentElement.classList.toggle('ga-standalone', inStandaloneMode());
   }
 
-  function setViewportUnit() {
-    var vh = window.innerHeight * 0.01;
-    document.documentElement.style.setProperty('--ga-vh', vh + 'px');
+  function setViewportUnits() {
+    var viewportHeight = window.innerHeight;
+
+    if (window.visualViewport && window.visualViewport.height) {
+      viewportHeight = window.visualViewport.height;
+    }
+
+    document.documentElement.style.setProperty('--ga-vh', (viewportHeight * 0.01) + 'px');
   }
 
-  setStandaloneClass();
-  setViewportUnit();
+  function diagnosticsEnabled() {
+    var params = new URLSearchParams(window.location.search);
+    var queryValue = params.get(DIAG_QUERY_KEY);
 
-  window.addEventListener('resize', function () {
+    if (queryValue === '1') {
+      window.localStorage.setItem(DIAG_STORAGE_KEY, '1');
+      return true;
+    }
+
+    if (queryValue === '0') {
+      window.localStorage.removeItem(DIAG_STORAGE_KEY);
+      return false;
+    }
+
+    return window.localStorage.getItem(DIAG_STORAGE_KEY) === '1';
+  }
+
+  function getSafeAreaValues() {
+    var styles = window.getComputedStyle(document.documentElement);
+    return {
+      top: styles.getPropertyValue('--ga-safe-top').trim(),
+      right: styles.getPropertyValue('--ga-safe-right').trim(),
+      bottom: styles.getPropertyValue('--ga-safe-bottom').trim(),
+      left: styles.getPropertyValue('--ga-safe-left').trim()
+    };
+  }
+
+  function buildDiagnosticsText() {
+    var vv = window.visualViewport;
+    var viewMain = document.querySelector('.view-main');
+    var page = document.querySelector('.page');
+    var safe = getSafeAreaValues();
+
+    var lines = [
+      'timestamp=' + new Date().toISOString(),
+      'url=' + window.location.href,
+      'standalone=' + String(inStandaloneMode()),
+      'display-mode-standalone=' + String(window.matchMedia('(display-mode: standalone)').matches),
+      'navigator.standalone=' + String(window.navigator.standalone === true),
+      'orientation=' + (window.screen.orientation ? window.screen.orientation.type : 'n/a'),
+      'screen=' + window.screen.width + 'x' + window.screen.height,
+      'inner=' + window.innerWidth + 'x' + window.innerHeight,
+      'outer=' + window.outerWidth + 'x' + window.outerHeight,
+      'docClient=' + document.documentElement.clientWidth + 'x' + document.documentElement.clientHeight,
+      'bodyClient=' + document.body.clientWidth + 'x' + document.body.clientHeight,
+      'css --ga-vh=' + window.getComputedStyle(document.documentElement).getPropertyValue('--ga-vh').trim(),
+      'safe-area top/right/bottom/left=' + safe.top + '/' + safe.right + '/' + safe.bottom + '/' + safe.left,
+      'visualViewport=' + (vv ? (vv.width + 'x' + vv.height + ' scale=' + vv.scale + ' offset=' + vv.offsetLeft + ',' + vv.offsetTop) : 'n/a'),
+      'view-main width=' + (viewMain ? Math.round(viewMain.getBoundingClientRect().width) : 'n/a'),
+      'page width=' + (page ? Math.round(page.getBoundingClientRect().width) : 'n/a'),
+      'userAgent=' + window.navigator.userAgent
+    ];
+
+    return lines.join('\n');
+  }
+
+  function ensureDiagnosticsPanel() {
+    var panel = document.getElementById('ga-viewport-diagnostics');
+
+    if (panel) return panel;
+
+    panel = document.createElement('div');
+    panel.id = 'ga-viewport-diagnostics';
+    panel.innerHTML = '<div class="ga-diag-header">Viewport diagnostics</div>' +
+      '<pre class="ga-diag-content"></pre>' +
+      '<button type="button" class="ga-diag-copy">Kopiér data</button>';
+
+    document.body.appendChild(panel);
+
+    panel.querySelector('.ga-diag-copy').addEventListener('click', function () {
+      var text = panel.querySelector('.ga-diag-content').textContent;
+      if (window.navigator.clipboard && window.navigator.clipboard.writeText) {
+        window.navigator.clipboard.writeText(text);
+      }
+    });
+
+    return panel;
+  }
+
+  function updateDiagnosticsPanel() {
+    if (!diagnosticsEnabled()) return;
+
+    document.documentElement.classList.add('ga-debug-viewport');
+
+    var panel = ensureDiagnosticsPanel();
+    panel.querySelector('.ga-diag-content').textContent = buildDiagnosticsText();
+  }
+
+  function refreshViewportState() {
     setStandaloneClass();
-    setViewportUnit();
-  });
+    setViewportUnits();
+    updateDiagnosticsPanel();
+  }
 
+  refreshViewportState();
+
+  window.addEventListener('resize', refreshViewportState);
   window.addEventListener('orientationchange', function () {
-    setStandaloneClass();
-    setViewportUnit();
+    window.setTimeout(refreshViewportState, 50);
+    window.setTimeout(refreshViewportState, 250);
   });
+
+  window.addEventListener('focus', refreshViewportState);
+
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', refreshViewportState);
+    window.visualViewport.addEventListener('scroll', updateDiagnosticsPanel);
+  }
 })();

--- a/www/styles.css
+++ b/www/styles.css
@@ -432,7 +432,6 @@ button#gem_indkobsseddel {
   --ga-vh: 1vh;
 }
 
-/* Brug dynamisk viewport-højde i app-sider */
 .view,
 .view-main,
 .page {
@@ -442,31 +441,15 @@ button#gem_indkobsseddel {
   min-height: 100dvh;
 }
 
-/* Kun i installeret webapp-tilstand (hjemmeskærm).
-   Både media query og klasse bruges for bred iOS-understøttelse. */
-@media (display-mode: standalone) {
-  body,
-  html.ga-standalone body {
-    padding-top: var(--ga-safe-top);
-    padding-left: var(--ga-safe-left);
-    padding-right: var(--ga-safe-right);
-    padding-bottom: var(--ga-safe-bottom);
-  }
-
-  .toolbar,
-  .tabbar,
-  .tabbar-icons,
-  html.ga-standalone .toolbar,
-  html.ga-standalone .tabbar,
-  html.ga-standalone .tabbar-icons {
-    padding-bottom: var(--ga-safe-bottom);
-  }
+html.ga-standalone,
+html.ga-standalone body {
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 html.ga-standalone body {
+  box-sizing: border-box;
   padding-top: var(--ga-safe-top);
-  padding-left: var(--ga-safe-left);
-  padding-right: var(--ga-safe-right);
   padding-bottom: var(--ga-safe-bottom);
 }
 
@@ -474,4 +457,56 @@ html.ga-standalone .toolbar,
 html.ga-standalone .tabbar,
 html.ga-standalone .tabbar-icons {
   padding-bottom: var(--ga-safe-bottom);
+}
+
+html.ga-standalone .page-content {
+  box-sizing: border-box;
+  padding-left: max(16px, var(--ga-safe-left));
+  padding-right: max(16px, var(--ga-safe-right));
+  padding-bottom: calc(16px + var(--ga-safe-bottom));
+}
+
+/* --- Diagnostic mode: viewport panel --- */
+#ga-viewport-diagnostics {
+  display: none;
+}
+
+html.ga-debug-viewport #ga-viewport-diagnostics {
+  position: fixed;
+  right: 8px;
+  bottom: 8px;
+  width: min(92vw, 360px);
+  max-height: 55vh;
+  overflow: auto;
+  z-index: 999999;
+  border-radius: 10px;
+  border: 1px solid #64748b;
+  background: rgba(15, 23, 42, 0.95);
+  color: #e2e8f0;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.45);
+  padding: 10px;
+  display: block;
+}
+
+html.ga-debug-viewport #ga-viewport-diagnostics .ga-diag-header {
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+html.ga-debug-viewport #ga-viewport-diagnostics .ga-diag-content {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.25;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+html.ga-debug-viewport #ga-viewport-diagnostics .ga-diag-copy {
+  margin-top: 8px;
+  width: 100%;
+  border: 1px solid #0ea5e9;
+  background: #0ea5e9;
+  color: #fff;
+  border-radius: 8px;
+  padding: 6px 10px;
 }


### PR DESCRIPTION
### Motivation

- Ensure the app computes dynamic viewport height more reliably across browsers and when the on-screen keyboard is present by preferring `window.visualViewport` when available. 
- Improve safe-area and standalone layout handling to avoid horizontal overflow and to respect device insets inside app pages. 
- Provide an on-device diagnostics panel to make it easier to inspect viewport, safe-area and related metrics when debugging layout issues.

### Description

- Reworked viewport logic in `www/pwa-viewport-fix.js` by renaming and replacing `setViewportUnit` with `setViewportUnits` which prefers `window.visualViewport.height` when available and sets `--ga-vh` accordingly. 
- Added a diagnostics mode controlled by the `gaDebugViewport` query parameter and `ga-debug-viewport` localStorage key, and implemented `buildDiagnosticsText`, `ensureDiagnosticsPanel`, `updateDiagnosticsPanel`, and `refreshViewportState` to show a copyable diagnostics panel. 
- Wired additional event listeners (`resize`, `orientationchange`, `focus`, and `visualViewport` `resize`/`scroll`) to keep viewport state and the diagnostics panel up to date. 
- Updated `www/styles.css` to declare safe-area CSS variables in `:root`, change `html.ga-standalone` rules to prevent horizontal overflow and apply box-sizing, add `.page-content` padding that respects safe-area insets, and add styles for the diagnostics panel (`#ga-viewport-diagnostics`).

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0cf996d8832885eded1060a3fc42)