### PR TITLE
Fix unused onclick argument error on Opskrifter add-item button

### DIFF
--- a/app.R
+++ b/app.R
@@ -1506,14 +1506,22 @@ server <- function(input, output, session) {
         inset = TRUE,
         strong = TRUE,
         tags$h3(ret_navn),
-        f7Button(
+        actionButton(
           inputId = paste0("opskrift_add_btn_", key),
           label = "Tilføj vare",
-          fill = TRUE,
-          color = "green",
+          class = "btn btn-success",
           onclick = sprintf(
             "Shiny.setInputValue('opskrift_addPressed', {key: '%s'}, {priority:'event'}); return false;",
             key
+          ),
+          style = paste(
+            "background:#22c55e;",
+            "color:#fff;",
+            "border:1px solid #16a34a;",
+            "border-radius:10px;",
+            "font-weight:600;",
+            "box-shadow:none;",
+            "background-image:none;"
           )
         ),
         br(),


### PR DESCRIPTION
### Motivation
- The "Tilføj vare" button in the Opskrifter tab used `f7Button(...)` with an `onclick` argument, which caused the runtime error "ubrugt argument (onclick = ...)" and prevented triggering the `opskrift_addPressed` event.
- The intent is to allow adding an item to a recipe via the existing `Shiny.setInputValue('opskrift_addPressed', ...)` JavaScript handler while keeping the button's green appearance.

### Description
- Replaced the `f7Button(...)` instance for the Opskrifter "Tilføj vare" control with `actionButton(...)` in `app.R` under the `output$opskrifter_ui` rendering.
- Preserved the JavaScript call `Shiny.setInputValue('opskrift_addPressed', {key: '%s'}, {priority:'event'});` as the button's `onclick` handler.
- Added `class = "btn btn-success"` and inline `style` attributes so the button remains visually a green primary action.

### Testing
- Located and inspected the relevant UI code with `rg` and printed the updated file region to confirm the replacement was applied.
- Attempted to parse the updated `app.R` with `Rscript -e 'parse(file="app.R")'`, but the parse check could not run because `Rscript` is not installed in the environment.
- No automated R unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d54da6706c8328b61b1b12d1c7ad66)